### PR TITLE
SceneGroupReference and an option to keep scenes that are in both groups

### DIFF
--- a/CookieUtilsExtras/Modules/Scenes/Editor/SceneGroupReferencePropertyDrawer.cs
+++ b/CookieUtilsExtras/Modules/Scenes/Editor/SceneGroupReferencePropertyDrawer.cs
@@ -1,0 +1,66 @@
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace CookieUtils.Extras.Scenes.Editor
+{
+    [CustomPropertyDrawer(typeof(SceneGroupReference))]
+    public class SceneGroupReferencePropertyDrawer : PropertyDrawer
+    {
+        public override VisualElement CreatePropertyGUI(SerializedProperty property)
+        {
+            VisualElement root = new();
+
+            var group = property.FindPropertyRelative("group");
+            var data = ScenesData.GetScenesData();
+
+            VisualElement layout = new() {
+                style = {
+                    flexDirection = FlexDirection.Row,
+                    paddingLeft = new StyleLength(Length.Pixels(4))
+                }
+            };
+
+            DropdownField dropdown = new() {
+                value = group.FindPropertyRelative("name").stringValue,
+                style = {
+                    width = new StyleLength(Length.Percent(50)),
+                }
+            };
+            
+            UpdateChoices();
+            
+            dropdown.RegisterCallback<FocusEvent>(_ => UpdateChoices());
+
+            dropdown.RegisterValueChangedCallback(e => {
+                group.boxedValue = data.FindSceneGroupFromName(e.newValue);
+                property.serializedObject.ApplyModifiedProperties();
+            });
+
+            Button edit = new(ScenesSettingsWindow.CreateWindow) {
+                text = "Edit"
+            };
+            
+            layout.Add(new Label(property.displayName) {
+                style = {
+                    unityTextAlign = TextAnchor.MiddleLeft
+                }
+            });
+            layout.Add(new VisualElement {
+                style = {
+                    flexGrow = 1f
+                }
+            });
+            layout.Add(dropdown);
+            layout.Add(edit);
+            root.Add(layout);
+
+            return root;
+
+            void UpdateChoices()
+            {
+                dropdown.choices = data.groups.ConvertAll(g => g.name);
+            }
+        }
+    }
+}

--- a/CookieUtilsExtras/Modules/Scenes/Editor/SceneGroupReferencePropertyDrawer.cs
+++ b/CookieUtilsExtras/Modules/Scenes/Editor/SceneGroupReferencePropertyDrawer.cs
@@ -11,7 +11,7 @@ namespace CookieUtils.Extras.Scenes.Editor
         {
             VisualElement root = new();
 
-            var group = property.FindPropertyRelative("group");
+            var name = property.FindPropertyRelative("name");
             var data = ScenesData.GetScenesData();
 
             VisualElement layout = new() {
@@ -22,7 +22,7 @@ namespace CookieUtils.Extras.Scenes.Editor
             };
 
             DropdownField dropdown = new() {
-                value = group.FindPropertyRelative("name").stringValue,
+                value = name.stringValue,
                 style = {
                     width = new StyleLength(Length.Percent(50)),
                 }
@@ -33,7 +33,7 @@ namespace CookieUtils.Extras.Scenes.Editor
             dropdown.RegisterCallback<FocusEvent>(_ => UpdateChoices());
 
             dropdown.RegisterValueChangedCallback(e => {
-                group.boxedValue = data.FindSceneGroupFromName(e.newValue);
+                name.stringValue = e.newValue;
                 property.serializedObject.ApplyModifiedProperties();
             });
 

--- a/CookieUtilsExtras/Modules/Scenes/Editor/SceneGroupReferencePropertyDrawer.cs.meta
+++ b/CookieUtilsExtras/Modules/Scenes/Editor/SceneGroupReferencePropertyDrawer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4f9f5d3b224f60d50838ecb89e526e8e

--- a/CookieUtilsExtras/Modules/Scenes/Editor/ScenesSettingsWindow.cs
+++ b/CookieUtilsExtras/Modules/Scenes/Editor/ScenesSettingsWindow.cs
@@ -1,12 +1,13 @@
 using UnityEditor;
 using UnityEditor.UIElements;
+using UnityEngine.UIElements;
 
 namespace CookieUtils.Extras.Scenes.Editor
 {
     public class ScenesSettingsWindow : EditorWindow
     {
         [MenuItem("Cookie Utils/Scenes/Scene groups")]
-        private static void CreateWindow()
+        public static void CreateWindow()
         {
             GetWindow<ScenesSettingsWindow>("Scenes");
         }
@@ -16,7 +17,9 @@ namespace CookieUtils.Extras.Scenes.Editor
             var data = ScenesData.GetScenesData();
 
             var dataInspector = new InspectorElement(data);
-
+            var scriptField = dataInspector.Q<PropertyField>("PropertyField:m_Script");
+            scriptField.parent.Remove(scriptField);
+            
             rootVisualElement.Add(dataInspector);
         }
     }

--- a/CookieUtilsExtras/Modules/Scenes/SceneGroup.cs
+++ b/CookieUtilsExtras/Modules/Scenes/SceneGroup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Eflatun.SceneReference;
+using UnityEngine;
 
 namespace CookieUtils.Extras.Scenes
 {
@@ -20,7 +21,8 @@ namespace CookieUtils.Extras.Scenes
 #endif
     public class SceneGroupReference
     {
-        public SceneGroup group;
+        public string name;
+        public SceneGroup Group => ScenesData.GetScenesData().FindSceneGroupFromName(name);
     }
 
     [Serializable]
@@ -30,8 +32,10 @@ namespace CookieUtils.Extras.Scenes
     public class SceneData
     {
         public SceneReference scene;
-        public string Name => scene.Name;
         public SceneType type;
+        [Tooltip("Whether to reload the scene if it's already loaded")]
+        public bool reloadIfExists = false;
+        public string Name => scene.Name;
     }
 
     public enum SceneType

--- a/CookieUtilsExtras/Modules/Scenes/SceneGroup.cs
+++ b/CookieUtilsExtras/Modules/Scenes/SceneGroup.cs
@@ -13,6 +13,15 @@ namespace CookieUtils.Extras.Scenes
         public string name;
         public List<SceneData> scenes;
     }
+    
+    [Serializable]
+#if ALCHEMY
+    [Alchemy.Inspector.DisableAlchemyEditor]
+#endif
+    public class SceneGroupReference
+    {
+        public SceneGroup group;
+    }
 
     [Serializable]
 #if ALCHEMY

--- a/CookieUtilsExtras/Modules/Scenes/Scenes.cs
+++ b/CookieUtilsExtras/Modules/Scenes/Scenes.cs
@@ -29,7 +29,7 @@ namespace CookieUtils.Extras.Scenes
                 }
             }
 
-            if (_data.startingGroup != "")
+            if (_data.startingGroup.group != null)
                 await LoadGroup(_data.startingGroup);
         }
         
@@ -38,22 +38,14 @@ namespace CookieUtils.Extras.Scenes
         #endif
         public static async Task LoadGroup(string groupName)
         {
-            if (string.IsNullOrWhiteSpace(groupName)) {
-                Debug.LogError("[CookieUtils.Extras.Scenes] Group name is null or whitespace!");
-                return;
-            }
-            
-            var targetGroup = _data.groups.Find(g => g.name == groupName);
-            
-            if (targetGroup == null) {
-                targetGroup = _data.groups.Find(g => string.Equals(g.name, groupName, StringComparison.CurrentCultureIgnoreCase));
-                if (targetGroup == null) {
-                    Debug.LogError($"[CookieUtils.Extras.Scenes] Group \"{groupName}\" not found!");
-                    return;
-                }
-            }
+            var targetGroup = _data.FindSceneGroupFromName(groupName);
 
             await LoadGroup(targetGroup);
+        }
+
+        public static async Task LoadGroup(SceneGroupReference group)
+        {
+            await LoadGroup(group.group);
         }
 
         public static async Task LoadGroup(SceneGroup targetGroup)

--- a/CookieUtilsExtras/Modules/Scenes/ScenesData.cs
+++ b/CookieUtilsExtras/Modules/Scenes/ScenesData.cs
@@ -15,7 +15,17 @@ namespace CookieUtils.Extras.Scenes
         public SceneReference bootstrapScene;
         public List<SceneGroup> groups;
 
+        private static ScenesData _instCached;
+
         public static ScenesData GetScenesData()
+        {
+            if (_instCached) return _instCached;
+
+            _instCached = LoadSceneData();
+            return _instCached;
+        }
+
+        private static ScenesData LoadSceneData()
         {
             if (!AssetDatabase.AssetPathExists($"Assets/{DataFolder}/{DataName}")) {
                 if (!AssetDatabase.IsValidFolder($"Assets/{DataFolder}")) {
@@ -27,8 +37,7 @@ namespace CookieUtils.Extras.Scenes
 
             return AssetDatabase.LoadAssetAtPath<ScenesData>($"Assets/{DataFolder}/{DataName}");
         }
-        
-        
+
 
         public SceneGroup FindSceneGroupFromName(string groupName)
         {

--- a/CookieUtilsExtras/Modules/Scenes/ScenesData.cs
+++ b/CookieUtilsExtras/Modules/Scenes/ScenesData.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Eflatun.SceneReference;
 using UnityEditor;
@@ -5,11 +6,14 @@ using UnityEngine;
 
 namespace CookieUtils.Extras.Scenes
 {
+#if ALCHEMY
+    [Alchemy.Inspector.DisableAlchemyEditor]
+#endif
     public class ScenesData : ScriptableObject
     {
+        public SceneGroupReference startingGroup;
         public SceneReference bootstrapScene;
         public List<SceneGroup> groups;
-        public string startingGroup;
 
         public static ScenesData GetScenesData()
         {
@@ -22,6 +26,27 @@ namespace CookieUtils.Extras.Scenes
             }
 
             return AssetDatabase.LoadAssetAtPath<ScenesData>($"Assets/{DataFolder}/{DataName}");
+        }
+        
+        
+
+        public SceneGroup FindSceneGroupFromName(string groupName)
+        {
+            if (string.IsNullOrWhiteSpace(groupName)) {
+                Debug.LogError("[CookieUtils.Extras.Scenes] Group name is null or whitespace!");
+                return null;
+            }
+            
+            var targetGroup = groups.Find(g => g.name == groupName);
+
+            if (targetGroup != null) return targetGroup;
+            {
+                targetGroup = groups.Find(g => string.Equals(g.name, groupName, StringComparison.CurrentCultureIgnoreCase));
+                if (targetGroup != null) return targetGroup;
+                
+                Debug.LogError($"[CookieUtils.Extras.Scenes] Group \"{groupName}\" not found!");
+                return null;
+            }
         }
 
         private const string DataFolder = "CookieUtils";

--- a/Samples/Scenes/KeepIfExistsTest.cs
+++ b/Samples/Scenes/KeepIfExistsTest.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Samples.Scenes
+{
+    public class KeepIfExistsTest : MonoBehaviour
+    {
+        private float _value;
+        
+        private void OnGUI()
+        {
+            GUILayout.Label($"This will stay between loads! {_value:####}");
+            _value = GUILayout.HorizontalSlider(_value, 0, 100);
+        }
+    }
+}

--- a/Samples/Scenes/KeepIfExistsTest.cs.meta
+++ b/Samples/Scenes/KeepIfExistsTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 17bfa9762f1dc5a92a86cc9025584e5a

--- a/Samples/Scenes/KeepIfExistsTest.unity
+++ b/Samples/Scenes/KeepIfExistsTest.unity
@@ -1,0 +1,170 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1645035901
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1645035903}
+  - component: {fileID: 1645035902}
+  m_Layer: 0
+  m_Name: KeepIfExistsTest
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1645035902
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645035901}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 17bfa9762f1dc5a92a86cc9025584e5a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: '::'
+--- !u!4 &1645035903
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1645035901}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1645035903}

--- a/Samples/Scenes/KeepIfExistsTest.unity.meta
+++ b/Samples/Scenes/KeepIfExistsTest.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 935faffc08e67306fbba88b36e6e987e
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples/Scenes/LoadSceneGroupButton.cs
+++ b/Samples/Scenes/LoadSceneGroupButton.cs
@@ -2,12 +2,15 @@ using CookieUtils.Extras.Scenes;
 using UnityEngine;
 using UnityEngine.UI;
 
-public class LoadSceneGroupButton : MonoBehaviour
+namespace Samples.Scenes
 {
-    [SerializeField] private SceneGroupReference group;
-
-    private void Awake()
+    public class LoadSceneGroupButton : MonoBehaviour
     {
-        GetComponent<Button>().onClick.AddListener(() => _ = Scenes.LoadGroup(group));
+        [SerializeField] private SceneGroupReference group;
+
+        private void Awake()
+        {
+            GetComponent<Button>().onClick.AddListener(() => _ = CookieUtils.Extras.Scenes.Scenes.LoadGroup(group));
+        }
     }
 }

--- a/Samples/Scenes/LoadSceneGroupButton.cs
+++ b/Samples/Scenes/LoadSceneGroupButton.cs
@@ -4,10 +4,10 @@ using UnityEngine.UI;
 
 public class LoadSceneGroupButton : MonoBehaviour
 {
-    [SerializeField] private string groupName;
+    [SerializeField] private SceneGroupReference group;
 
     private void Awake()
     {
-        GetComponent<Button>().onClick.AddListener(() => _ = Scenes.LoadGroup(groupName));
+        GetComponent<Button>().onClick.AddListener(() => _ = Scenes.LoadGroup(group));
     }
 }

--- a/Samples/Scenes/Scene1.unity
+++ b/Samples/Scenes/Scene1.unity
@@ -468,7 +468,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6f3e743752853980db4359d5aadce30c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: '::'
-  groupName: LevelTwo
+  group:
+    group:
+      name: LevelTwo
+      scenes:
+      - scene:
+          asset: {fileID: 102900000, guid: 695b1aaeb221c02398ac3fb5ad01c3a0, type: 3}
+          guid: 695b1aaeb221c02398ac3fb5ad01c3a0
+        type: 0
+      - scene:
+          asset: {fileID: 102900000, guid: c7398dce4fca8115983babbb7a6a4740, type: 3}
+          guid: c7398dce4fca8115983babbb7a6a4740
+        type: 1
 --- !u!1 &940258619
 GameObject:
   m_ObjectHideFlags: 0

--- a/Samples/Scenes/Scene1.unity
+++ b/Samples/Scenes/Scene1.unity
@@ -469,17 +469,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: '::'
   group:
-    group:
-      name: LevelTwo
-      scenes:
-      - scene:
-          asset: {fileID: 102900000, guid: 695b1aaeb221c02398ac3fb5ad01c3a0, type: 3}
-          guid: 695b1aaeb221c02398ac3fb5ad01c3a0
-        type: 0
-      - scene:
-          asset: {fileID: 102900000, guid: c7398dce4fca8115983babbb7a6a4740, type: 3}
-          guid: c7398dce4fca8115983babbb7a6a4740
-        type: 1
+    name: LevelTwo
 --- !u!1 &940258619
 GameObject:
   m_ObjectHideFlags: 0

--- a/Samples/Scenes/Scene2.unity
+++ b/Samples/Scenes/Scene2.unity
@@ -469,13 +469,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: '::'
   group:
-    group:
-      name: LevelOne
-      scenes:
-      - scene:
-          asset: {fileID: 102900000, guid: 666db8a591b33a7beab72bd52639cf0d, type: 3}
-          guid: 666db8a591b33a7beab72bd52639cf0d
-        type: 0
+    name: LevelOne
 --- !u!1 &940258619
 GameObject:
   m_ObjectHideFlags: 0

--- a/Samples/Scenes/Scene2.unity
+++ b/Samples/Scenes/Scene2.unity
@@ -468,7 +468,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6f3e743752853980db4359d5aadce30c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: '::'
-  groupName: LevelOne
+  group:
+    group:
+      name: LevelOne
+      scenes:
+      - scene:
+          asset: {fileID: 102900000, guid: 666db8a591b33a7beab72bd52639cf0d, type: 3}
+          guid: 666db8a591b33a7beab72bd52639cf0d
+        type: 0
 --- !u!1 &940258619
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Added a SceneGroupReference class which allows the user to select scenes from a list and an option to keep the scene loaded if it's present in both the current and new scene group